### PR TITLE
Task 4 - Implementing proxy server

### DIFF
--- a/apps/stocks-api/src/environments/environment.ts
+++ b/apps/stocks-api/src/environments/environment.ts
@@ -3,5 +3,7 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  STOCK_DATA_URL: 'https://cloud.iexapis.com/beta/stock/',
+  API_KEY: 'pk_b6f42f13ba4e41e5a65a9f8886b1b952'
 };

--- a/apps/stocks-api/src/main.ts
+++ b/apps/stocks-api/src/main.ts
@@ -3,6 +3,7 @@
  * This is only a minimal backend to get started.
  **/
 import { Server } from 'hapi';
+import { environment } from './environments/environment';
 
 const init = async () => {
   const server = new Server({
@@ -10,13 +11,41 @@ const init = async () => {
     host: 'localhost'
   });
 
+  const Wreck = require('wreck');
+
+  const getStockData = async (symbol: string, period: string) => {
+    try {
+      // GET Stock Data response
+      const { stockDataResponse, payload } = await Wreck.get(
+        `${environment.STOCK_DATA_URL}${symbol}/chart/${period}?token=${
+          environment.API_KEY
+        }`,
+        {
+          json: true
+        }
+      );
+      return payload;
+    } catch (error) {
+      return error;
+    }
+  };
+
+  server.method('getStockData', getStockData, {
+    cache: {
+      expiresIn: 10 * 3000,
+      generateTimeout: 10000
+    }
+  });
+
   server.route({
     method: 'GET',
-    path: '/',
-    handler: (request, h) => {
-      return {
-        hello: 'world'
-      };
+    path: '/api/v1/stockData',
+    handler: async request => {
+      const stockData = server.methods.getStockData(
+        request.query.symbol,
+        request.query.period
+      );
+      return stockData;
     }
   });
 

--- a/libs/shared/ui/chart/src/lib/chart/chart.component.html
+++ b/libs/shared/ui/chart/src/lib/chart/chart.component.html
@@ -1,5 +1,5 @@
 <google-chart
-  *ngIf="data"
+  *ngIf="(data$ | async) as chartData"
   [title]="chart.title"
   [type]="chart.type"
   [data]="chartData"

--- a/libs/shared/ui/chart/src/lib/chart/chart.component.ts
+++ b/libs/shared/ui/chart/src/lib/chart/chart.component.ts
@@ -1,6 +1,4 @@
 import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   Input,
   OnInit
@@ -23,7 +21,7 @@ export class ChartComponent implements OnInit {
     columnNames: string[];
     options: any;
   };
-  constructor(private cd: ChangeDetectorRef) {}
+  constructor() {}
 
   ngOnInit() {
     this.chart = {
@@ -34,6 +32,5 @@ export class ChartComponent implements OnInit {
       options: { title: `Stock price`, width: '600', height: '400' }
     };
 
-    this.data$.subscribe(newData => (this.chartData = newData));
   }
 }

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
@@ -23,11 +23,9 @@ export class PriceQueryEffects {
     {
       run: (action: FetchPriceQuery, state: PriceQueryPartialState) => {
         return this.httpClient
-          .get(
-            `${this.env.apiURL}/beta/stock/${action.symbol}/chart/${
-              action.period
-            }?token=${this.env.apiKey}`
-          )
+          .get('api/v1/stockData', {
+            params: { symbol: action.symbol, period: action.period }
+          })
           .pipe(
             map(resp => new PriceQueryFetched(resp as PriceQueryResponse[]))
           );


### PR DESCRIPTION
```
Technical requirement: the server `stocks-api` should be used as a proxy
to make calls. Calls should be cached in memory to avoid querying for the
same data. If a query is not in cache we should call-through to the API.
```

1. Proxy server implementation done.
2. Hapi will make an API call to fetch stock data from stock website.
3. Hapi will provide the data to client and also caches the data so that when the same data is requested by client, data can be fetched from cache instead of fetching from stock website.

![Graph_Population](https://user-images.githubusercontent.com/60497621/74232559-0e5b9880-4cef-11ea-9f4c-0d235c4de9b6.PNG)

![Cache_Data](https://user-images.githubusercontent.com/60497621/74232574-16b3d380-4cef-11ea-8961-ca720700bf0a.PNG)
